### PR TITLE
Add route to create criteria and criteria scores

### DIFF
--- a/backend/src/controllers/criterias.controller.ts
+++ b/backend/src/controllers/criterias.controller.ts
@@ -1,3 +1,4 @@
+import { CreateCriteriaDto } from '@/dtos/create.criteria.dto';
 import { Criteria } from '@/entity/criteria.entity';
 import CriteriasService from '@/services/criterias.service';
 import { NextFunction, Request, Response } from 'express';
@@ -9,6 +10,16 @@ class CriteriasController {
     try {
       const criterias: Criteria[] = await this.criteriaService.findAll();
       res.status(200).json({ data: criterias });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public create = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const payload: CreateCriteriaDto = req.body;
+      const criteria: Criteria = await this.criteriaService.create(payload);
+      res.status(200).json({ data: criteria });
     } catch (error) {
       next(error);
     }

--- a/backend/src/dtos/create.criteria.dto.ts
+++ b/backend/src/dtos/create.criteria.dto.ts
@@ -1,0 +1,6 @@
+import { CriteriaScore } from '@/entity/criteriaScore.entity';
+
+export interface CreateCriteriaDto {
+  name: string;
+  criteriaScores: CriteriaScore[];
+}

--- a/backend/src/entity/criteria.entity.ts
+++ b/backend/src/entity/criteria.entity.ts
@@ -15,6 +15,6 @@ export class Criteria {
   @ManyToMany(() => Method)
   method: Method[];
 
-  @OneToMany(() => CriteriaScore, criteriaScore => criteriaScore.criteria)
+  @OneToMany(() => CriteriaScore, criteriaScore => criteriaScore.criteria, { cascade: true })
   criteriaScores: CriteriaScore[];
 }

--- a/backend/src/routes/criterias.route.ts
+++ b/backend/src/routes/criterias.route.ts
@@ -13,6 +13,7 @@ class CriteriasRoute implements Routes {
 
   private initializeRoutes() {
     this.router.get(`${this.path}/`, this.controller.findAll);
+    this.router.post(`${this.path}/`, this.controller.create);
   }
 }
 

--- a/backend/src/services/criterias.service.ts
+++ b/backend/src/services/criterias.service.ts
@@ -1,3 +1,4 @@
+import { CreateCriteriaDto } from '@/dtos/create.criteria.dto';
 import { Criteria } from '@/entity/criteria.entity';
 import { getRepository, Repository } from 'typeorm';
 
@@ -14,6 +15,10 @@ class CriteriasService {
 
   public async findAll() {
     return this.criteriaRepository.find();
+  }
+
+  public async create(payload: CreateCriteriaDto) {
+    return this.criteriaRepository.save({ ...payload });
   }
 }
 


### PR DESCRIPTION
Closes https://team-1614641739934.atlassian.net/browse/TABD-131

Observação: o payload segue o seguinte formato

```json
{
    "name": "Teste 3",
    "criteriaScores": [
        {
           "name": "A",
           "value": 1 ,
           "criteriaScoreId": 1
        },
        {
           "name": "B",
           "value": 2,
           "criteriaScoreId": 2
        },
        {
            "name": "C",
            "value": 3
        }
    ]
}
```

Quando `criteriaScoreId` é passado, é feito um find, ou seja, não é criado um novo criteriaScore. Mas quando o id não é passado, o typeorm automaticamente cria um novo `criteriaScore`.